### PR TITLE
feat: add Hint component and integrate into FragmentWeb

### DIFF
--- a/apps/web/components/hint.tsx
+++ b/apps/web/components/hint.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   Tooltip,
   TooltipContent,

--- a/apps/web/components/hint.tsx
+++ b/apps/web/components/hint.tsx
@@ -1,0 +1,31 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@workspace/design-system/components/ui/tooltip';
+
+type Props = {
+  children: React.ReactNode;
+  text: string;
+  side?: 'top' | 'bottom' | 'left' | 'right';
+  align?: 'start' | 'center' | 'end';
+};
+
+export const Hint = ({
+  children,
+  text,
+  side = 'top',
+  align = 'center',
+}: Props) => {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipContent align={align} side={side}>
+          <p>{text}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/apps/web/modules/projects/ui/components/fragment-web.tsx
+++ b/apps/web/modules/projects/ui/components/fragment-web.tsx
@@ -1,0 +1,72 @@
+import { Button } from '@workspace/design-system/components/ui/button';
+import { ExternalLinkIcon, RefreshCcwIcon } from 'lucide-react';
+import { useState } from 'react';
+import { Hint } from '@/components/hint';
+import type { Fragment } from '@/generated/prisma';
+
+type Props = {
+  data: Fragment;
+};
+
+const COPIED_TIMEOUT = 2000; // 2 seconds
+
+export const FragmentWeb = ({ data }: Props) => {
+  const [copied, setCopied] = useState(false);
+  const [fragmentKey, setFragmentKey] = useState(0);
+
+  const onRefresh = () => {
+    setFragmentKey((prev) => prev + 1);
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(data.sandboxUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), COPIED_TIMEOUT);
+  };
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      <div className="flex items-center gap-x-2 border-b bg-sidebar p-2">
+        <Hint align="start" side="bottom" text="Refresh">
+          <Button onClick={onRefresh} size="sm" variant="outline">
+            <RefreshCcwIcon />
+          </Button>
+        </Hint>
+        <Hint align="start" side="bottom" text="Click to copy">
+          <Button
+            className="flex-1 justify-start text-start font-normal"
+            disabled={!data.sandboxUrl || copied}
+            onClick={handleCopy}
+            size="sm"
+            variant="outline"
+          >
+            <span className="truncate">{data.sandboxUrl}</span>
+          </Button>
+        </Hint>
+        <Hint align="start" side="bottom" text="Open in new tab">
+          <Button
+            disabled={!data.sandboxUrl}
+            onClick={() => {
+              if (!data.sandboxUrl) {
+                return;
+              }
+              window.open(data.sandboxUrl, '_blank');
+            }}
+            size="sm"
+            variant="outline"
+          >
+            <ExternalLinkIcon />
+          </Button>
+        </Hint>
+      </div>
+      <iframe
+        className="h-full w-full"
+        key={fragmentKey}
+        loading="lazy"
+        sandbox="allow-forms allow-scripts allow-same-origin"
+        src={data.sandboxUrl}
+        title="Fragment Web View"
+      />
+    </div>
+  );
+};

--- a/apps/web/modules/projects/ui/components/fragment-web.tsx
+++ b/apps/web/modules/projects/ui/components/fragment-web.tsx
@@ -1,9 +1,10 @@
+'use client';
+
 import { Button } from '@workspace/design-system/components/ui/button';
 import { ExternalLinkIcon, RefreshCcwIcon } from 'lucide-react';
 import { useState } from 'react';
 import { Hint } from '@/components/hint';
 import type { Fragment } from '@/generated/prisma';
-
 type Props = {
   data: Fragment;
 };

--- a/apps/web/modules/projects/ui/views/project-view.tsx
+++ b/apps/web/modules/projects/ui/views/project-view.tsx
@@ -7,6 +7,7 @@ import {
 } from '@workspace/design-system/components/ui/resizable';
 import { Suspense, useState } from 'react';
 import type { Fragment } from '@/generated/prisma';
+import { FragmentWeb } from '@/modules/projects/ui/components/fragment-web';
 import { MessagesContainer } from '@/modules/projects/ui/components/messages-container';
 import { ProjectHeader } from '@/modules/projects/ui/components/project-header';
 
@@ -43,7 +44,7 @@ export const ProjectView = ({ projectId }: Props) => {
           defaultSize={65}
           minSize={50}
         >
-          <h2 className="mb-2 font-semibold text-xl">Messages:</h2>
+          {!!activeFragment && <FragmentWeb data={activeFragment} />}
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a reusable Hint tooltip with configurable position and alignment for clearer UI guidance.
  - Added a Fragment preview panel with an embedded sandbox, including:
    - Refresh to reload the preview.
    - Copy URL to clipboard with brief confirmation state.
    - Open in new tab for quick access.
    - Controls auto-disable when no URL is available.
  - Project view now shows the Fragment preview in the right pane when a fragment is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->